### PR TITLE
fix: wrap in pre tag and escape html

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -107,10 +107,11 @@ function addSourceViewButton(detailsMenu: Element, issue: any, comments: any): v
             } else {
                 button.innerText = 'View original';
                 const body = detectIssueOrCommentAndFetchBody(detailsMenu, issue, comments);
-                const sourceCode = replaceEscapeSequences(body);
+                const pre = document.createElement('pre');
+                pre.textContent = body;
 
                 // Replace with the source code
-                commentBody.innerHTML = sourceCode;
+                commentBody.innerHTML = pre.outerHTML;
             }
 
             // Toggle the flag
@@ -141,14 +142,6 @@ function detectIssueOrCommentAndFetchBody(detailsMenu: Element, issue: any, comm
     }
 
     return '';
-}
-
-function replaceEscapeSequences(sourceCode: string): string {
-    return sourceCode
-        .replace(/(?:\r\n|\r|\n)/g, '<br>') // Replace carriage returns with <br>
-        .replace(/(?:\t)/g, '&nbsp;&nbsp;&nbsp;&nbsp;') // Replace tabs with four non-breaking spaces
-        .replace(/(?:\f)/g, '<br>') // Form feed, treated as a new line in HTML
-        .replace(/(?:\v)/g, '<br>'); // Vertical tab, treated as a new line in HTML
 }
 
 const showToast = (message: string, timeout = 5000) => {


### PR DESCRIPTION
Before (GitHub has a CSP but it can still be dangerous):
![Peek 2024-06-13 12-31](https://github.com/SavageCore/github-comment-view-source/assets/55899582/6575c07a-23ec-43d6-980b-0fee41fdc65d)

After:
![Peek 2024-06-13 12-42](https://github.com/SavageCore/github-comment-view-source/assets/55899582/45893f97-073e-4cbb-a59c-1fb3d75bc8e6)
